### PR TITLE
Add translation testing workflow

### DIFF
--- a/.github/workflows/test-translation.yml
+++ b/.github/workflows/test-translation.yml
@@ -1,0 +1,80 @@
+# python-docs-translations sample workflows, adapted to be contained in a single file
+# For more information, see https://python-docs-transifex-automation.readthedocs.io/workflows.html
+name: Test translation workflow
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+    branches:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ '3.14' ]
+    continue-on-error: true
+    steps:
+      - uses: actions/setup-python@master
+        with:
+          python-version: 3
+      - run: pip install sphinx-lint
+      - uses: actions/checkout@master
+        with:
+          ref: ${{ matrix.version }}
+      - uses: rffontenelle/sphinx-lint-problem-matcher@v1.0.0
+      - run: sphinx-lint
+
+  build-translation:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ '3.14' ]
+        format: [ html, latex ]
+    steps:
+      - uses: actions/setup-python@master
+        with:
+          python-version: 3.12  # pinned for Sphinx 3.4.3 to build 3.10
+      - uses: actions/checkout@master
+        with:
+          repository: python/cpython
+          ref: ${{ matrix.version }}
+      - run: make venv
+        working-directory: ./Doc
+      - uses: actions/checkout@master
+        with:
+          ref: ${{ matrix.version }}
+          path: Doc/locales/ro/LC_MESSAGES
+      - run: git pull
+        working-directory: ./Doc/locales/ro/LC_MESSAGES
+      - uses: sphinx-doc/github-problem-matcher@v1.1
+      - run: make -e SPHINXOPTS="--color -D language='ro' -W --keep-going" ${{ matrix.format }}
+        working-directory: ./Doc
+      - uses: actions/upload-artifact@master
+        if: success() || failure()
+        with:
+          name: build-${{ matrix.version }}-${{ matrix.format }}
+          path: Doc/build/${{ matrix.format }}
+
+  output-pdf:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ '3.14' ]
+    needs: [ 'build-translation' ]
+    steps:
+      - uses: actions/download-artifact@master
+        with:
+          name: build-${{ matrix.version }}-latex
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y latexmk texlive-xetex fonts-freefont-otf xindy
+      - run: make
+      - uses: actions/upload-artifact@master
+        with:
+          name: build-${{ matrix.version }}-pdf
+          path: .


### PR DESCRIPTION
Hello,

Closes #2  I have added this workflow, however for it to run your current "main" branch needs to be renamed to the version it is translating, I assume this is 3.14 or 3.13. (In this PR, I have it set to 3.14, but if it is 3.13 let me know and I will update it)

It can be renamed to the version from the [branches page](https://github.com/python/python-docs-ro/branches), as shown below:

<img width="616" height="451" alt="Screenshot From 2025-07-30 09-58-30" src="https://github.com/user-attachments/assets/40b504d3-a0c7-43cf-ab51-0a732a075c43" />

For more information about the workflows, please consult [their documentation](https://python-docs-transifex-automation.readthedocs.io/workflows.html) or ask!